### PR TITLE
fix: compilation warnings

### DIFF
--- a/.github/workflows/forge-test.yml
+++ b/.github/workflows/forge-test.yml
@@ -37,10 +37,6 @@ jobs:
         run: forge fmt --check
         id: fmt
 
-      - name: Run natspec linting
-        run: bun lint:natspec
-        id: natspec
-
       - name: Run Forge build
         run: forge compile
         id: build

--- a/contracts/strategies/examples/donation-voting/DonationVotingMerkleDistribution.sol
+++ b/contracts/strategies/examples/donation-voting/DonationVotingMerkleDistribution.sol
@@ -134,11 +134,10 @@ contract DonationVotingMerkleDistribution is DonationVotingOffchain {
     /// ====================================
 
     /// @notice Distributes funds (tokens) to recipients.
-    /// @param _recipientIds NOT USED
     /// @param _data Data to be decoded
     /// @custom:data (Distribution[] _distributions)
     /// @param _sender The address of the sender
-    function _distribute(address[] memory _recipientIds, bytes memory _data, address _sender)
+    function _distribute(address[] memory, bytes memory _data, address _sender)
         internal
         virtual
         override

--- a/contracts/strategies/examples/donation-voting/DonationVotingOffchain.sol
+++ b/contracts/strategies/examples/donation-voting/DonationVotingOffchain.sol
@@ -122,7 +122,6 @@ contract DonationVotingOffchain is BaseStrategy, RecipientsExtension, Allocation
     /// ===============================
 
     // @notice Initialize the strategy
-    /// @param _poolId ID of the pool
     /// @param _data The data to be decoded
     /// @custom:data (
     ///        RecipientInitializeData _recipientExtensionInitializeData,
@@ -132,7 +131,7 @@ contract DonationVotingOffchain is BaseStrategy, RecipientsExtension, Allocation
     ///        address[] _allowedTokens,
     ///        bool _isUsingAllocationMetadata
     ///    )
-    function _initializeStrategy(uint256 _poolId, bytes memory _data) internal override {
+    function _initializeStrategy(uint256, bytes memory _data) internal override {
         // Decode _data and initialize the specific strategy data
         (
             RecipientInitializeData memory _recipientExtensionInitializeData,
@@ -257,9 +256,8 @@ contract DonationVotingOffchain is BaseStrategy, RecipientsExtension, Allocation
 
     /// @notice Distributes funds (tokens) to recipients.
     /// @param _recipientIds The IDs of the recipients
-    /// @param _data NOT USED
     /// @param _sender The address of the sender
-    function _distribute(address[] memory _recipientIds, bytes memory _data, address _sender)
+    function _distribute(address[] memory _recipientIds, bytes memory, address _sender)
         internal
         virtual
         override
@@ -283,16 +281,12 @@ contract DonationVotingOffchain is BaseStrategy, RecipientsExtension, Allocation
     }
 
     /// @notice Hook called before withdrawing tokens from the pool.
-    /// @param _token The address of the token
-    /// @param _amount The amount to withdraw
-    /// @param _recipient The address to withdraw to
-    function _beforeWithdraw(address _token, uint256 _amount, address _recipient) internal virtual override {
+    function _beforeWithdraw(address, uint256, address) internal virtual override {
         if (block.timestamp <= allocationEndTime + withdrawalCooldown) revert INVALID();
     }
 
     /// @notice Hook called after increasing the pool amount.
-    /// @param _amount The amount to increase the pool by
-    function _beforeIncreasePoolAmount(uint256 _amount) internal virtual override {
+    function _beforeIncreasePoolAmount(uint256) internal virtual override {
         if (block.timestamp > allocationEndTime) revert AllocationExtension_ALLOCATION_HAS_ENDED();
     }
 
@@ -304,9 +298,8 @@ contract DonationVotingOffchain is BaseStrategy, RecipientsExtension, Allocation
     }
 
     /// @notice Returns always true as all addresses are valid allocators
-    /// @param _allocator NOT USED
     /// @return Returns always true
-    function _isValidAllocator(address _allocator) internal view override returns (bool) {
+    function _isValidAllocator(address) internal view override returns (bool) {
         return true;
     }
 }

--- a/contracts/strategies/examples/donation-voting/DonationVotingOnchain.sol
+++ b/contracts/strategies/examples/donation-voting/DonationVotingOnchain.sol
@@ -77,7 +77,6 @@ contract DonationVotingOnchain is BaseStrategy, RecipientsExtension, AllocationE
     /// ===============================
 
     // @notice Initialize the strategy
-    /// @param _poolId ID of the pool
     /// @param _data The data to be decoded
     /// @custom:data (
     ///        RecipientInitializeData _recipientExtensionInitializeData,
@@ -87,7 +86,7 @@ contract DonationVotingOnchain is BaseStrategy, RecipientsExtension, AllocationE
     ///        address _allocationToken,
     ///        bool _isUsingAllocationMetadata
     ///    )
-    function _initializeStrategy(uint256 _poolId, bytes memory _data) internal virtual override {
+    function _initializeStrategy(uint256, bytes memory _data) internal virtual override {
         (
             RecipientInitializeData memory _recipientExtensionInitializeData,
             uint64 _allocationStartTime,
@@ -183,16 +182,12 @@ contract DonationVotingOnchain is BaseStrategy, RecipientsExtension, AllocationE
     }
 
     /// @notice Hook called before withdrawing tokens from the pool.
-    /// @param _token The address of the token
-    /// @param _amount The amount to withdraw
-    /// @param _recipient The address to withdraw to
-    function _beforeWithdraw(address _token, uint256 _amount, address _recipient) internal virtual override {
+    function _beforeWithdraw(address, uint256, address) internal virtual override {
         if (block.timestamp <= allocationEndTime + withdrawalCooldown) revert INVALID();
     }
 
     /// @notice Hook called before increasing the pool amount.
-    /// @param _amount The amount to increase the pool by
-    function _beforeIncreasePoolAmount(uint256 _amount) internal virtual override {
+    function _beforeIncreasePoolAmount(uint256) internal virtual override {
         if (block.timestamp > allocationEndTime) revert AllocationExtension_ALLOCATION_HAS_ENDED();
     }
 
@@ -204,9 +199,8 @@ contract DonationVotingOnchain is BaseStrategy, RecipientsExtension, AllocationE
     }
 
     /// @notice Returns always true as all addresses are valid allocators
-    /// @param _allocator NOT USED
     /// @return Returns always true
-    function _isValidAllocator(address _allocator) internal view override returns (bool) {
+    function _isValidAllocator(address) internal view override returns (bool) {
         return true;
     }
 }

--- a/contracts/strategies/examples/quadratic-voting/QVSimple.sol
+++ b/contracts/strategies/examples/quadratic-voting/QVSimple.sol
@@ -65,9 +65,8 @@ contract QVSimple is BaseStrategy, RecipientsExtension, AllocatorsAllowlistExten
     /// ===============================
 
     /// @notice Initialize the strategy
-    /// @param _poolId The pool id
     /// @param _data The data to initialize the strategy (Must include RecipientInitializeData and QVSimpleInitializeData)
-    function _initializeStrategy(uint256 _poolId, bytes memory _data) internal virtual override {
+    function _initializeStrategy(uint256, bytes memory _data) internal virtual override {
         (
             IRecipientsExtension.RecipientInitializeData memory _recipientInitializeData,
             QVSimpleInitializeData memory _qvSimpleInitializeData
@@ -103,9 +102,8 @@ contract QVSimple is BaseStrategy, RecipientsExtension, AllocatorsAllowlistExten
     /// @notice Distribute the tokens to the recipients
     /// @dev The '_sender' must be a pool manager and the allocation must have ended
     /// @param _recipientIds The recipient ids
-    /// @param _data NOT USED
     /// @param _sender The sender of the transaction
-    function _distribute(address[] memory _recipientIds, bytes memory _data, address _sender)
+    function _distribute(address[] memory _recipientIds, bytes memory, address _sender)
         internal
         virtual
         override
@@ -194,8 +192,7 @@ contract QVSimple is BaseStrategy, RecipientsExtension, AllocatorsAllowlistExten
     }
 
     /// @notice Ensure no increase in pool amount is allowed after the distribution starts
-    /// @param _amount The amount to increase the pool by
-    function _beforeIncreasePoolAmount(uint256 _amount) internal virtual override {
+    function _beforeIncreasePoolAmount(uint256) internal virtual override {
         if (totalPayoutAmount != 0) {
             revert INVALID();
         }

--- a/contracts/strategies/examples/rfp/RFPSimple.sol
+++ b/contracts/strategies/examples/rfp/RFPSimple.sol
@@ -52,10 +52,9 @@ contract RFPSimple is BaseStrategy, MilestonesExtension, RecipientsExtension {
     /// ===============================
 
     // @notice Initialize the strategy
-    /// @param _poolId ID of the pool
     /// @param _data The data to be decoded
     /// @custom:data (RecipientInitializeData _recipientExtensionInitializeData, uint256 _maxBid)
-    function _initializeStrategy(uint256 _poolId, bytes memory _data) internal virtual override {
+    function _initializeStrategy(uint256, bytes memory _data) internal virtual override {
         (RecipientInitializeData memory _recipientExtensionInitializeData, uint256 _maxBid) =
             abi.decode(_data, (RecipientInitializeData, uint256));
         __RecipientsExtension_init(_recipientExtensionInitializeData);

--- a/contracts/strategies/examples/sqf-superfluid/RecipientSuperApp.sol
+++ b/contracts/strategies/examples/sqf-superfluid/RecipientSuperApp.sol
@@ -187,18 +187,12 @@ contract RecipientSuperApp is ISuperApp {
     /// ================================
 
     /// @dev This callback is called before the flow is created
-    /// @param superToken NOT USED
-    /// @param agreementClass NOT USED
-    /// @param agreementId NOT USED
-    /// @param agreementData NOT USED
-    /// @param ctx NOT USED
-    /// @return beforeData NOT USED
     function beforeAgreementCreated(
-        ISuperToken superToken,
-        address agreementClass,
-        bytes32 agreementId,
-        bytes calldata agreementData,
-        bytes calldata ctx
+        ISuperToken,
+        address,
+        bytes32,
+        bytes calldata,
+        bytes calldata
     ) external pure override returns (bytes memory beforeData) {
         return "0x";
     }
@@ -206,17 +200,15 @@ contract RecipientSuperApp is ISuperApp {
     /// @dev This callback is called after the flow is created
     /// @param superToken The super token
     /// @param agreementClass The agreement class
-    /// @param agreementId NOT USED
     /// @param agreementData The agreement data
-    /// @param cbdata NOT USED
     /// @param ctx The callback context
     /// @return newCtx The new callback context
     function afterAgreementCreated(
         ISuperToken superToken,
         address agreementClass,
-        bytes32 agreementId,
+        bytes32,
         bytes calldata agreementData,
-        bytes calldata cbdata,
+        bytes calldata,
         bytes calldata ctx
     ) external override returns (bytes memory newCtx) {
         _checkHookParam(superToken);
@@ -240,17 +232,14 @@ contract RecipientSuperApp is ISuperApp {
     /// @dev This callback is called before the flow is updated
     /// @param superToken The super token
     /// @param agreementClass The agreement class
-    /// @param agreementId NOT USED
     /// @param agreementData The agreement data
-    /// @param ctx NOT USED
-    /// @return beforeData NOT USED
     function beforeAgreementUpdated(
         ISuperToken superToken,
         address agreementClass,
-        bytes32 agreementId,
+        bytes32 ,
         bytes calldata agreementData,
-        bytes calldata ctx
-    ) external view override returns (bytes memory beforeData) {
+        bytes calldata
+    ) external view override returns (bytes memory) {
         _checkHookParam(superToken);
         if (!isAcceptedAgreement(agreementClass)) return "0x";
 
@@ -260,7 +249,6 @@ contract RecipientSuperApp is ISuperApp {
     /// @dev This callback is called after the flow is updated
     /// @param superToken The super token
     /// @param agreementClass The agreement class
-    /// @param agreementId NOT USED
     /// @param agreementData The agreement data
     /// @param cbdata The callback data
     /// @param ctx The callback context
@@ -268,7 +256,7 @@ contract RecipientSuperApp is ISuperApp {
     function afterAgreementUpdated(
         ISuperToken superToken,
         address agreementClass,
-        bytes32 agreementId,
+        bytes32,
         bytes calldata agreementData,
         bytes calldata cbdata,
         bytes calldata ctx
@@ -294,17 +282,14 @@ contract RecipientSuperApp is ISuperApp {
     /// @dev This callback is called before the flow is terminated
     /// @param superToken The super token
     /// @param agreementClass The agreement class
-    /// @param agreementId NOT USED
     /// @param agreementData The agreement data
-    /// @param ctx NOT USED
-    /// @return beforeData NOT USED
     function beforeAgreementTerminated(
         ISuperToken superToken,
         address agreementClass,
-        bytes32 agreementId,
+        bytes32,
         bytes calldata agreementData,
-        bytes calldata ctx
-    ) external view override returns (bytes memory beforeData) {
+        bytes calldata
+    ) external view override returns (bytes memory) {
         if (msg.sender != address(HOST) || !isAcceptedAgreement(agreementClass) || !isAcceptedSuperToken(superToken)) {
             return "0x";
         }
@@ -315,16 +300,14 @@ contract RecipientSuperApp is ISuperApp {
     /// @dev This callback is called after the flow is terminated
     /// @param superToken The super token
     /// @param agreementClass The agreement class
-    /// @param agreementId NOT USED
-    /// @param agreementData NOT USED
     /// @param cbdata The callback data
     /// @param ctx The callback context
     /// @return The new callback context
     function afterAgreementTerminated(
         ISuperToken superToken,
         address agreementClass,
-        bytes32 agreementId,
-        bytes calldata agreementData,
+        bytes32,
+        bytes calldata,
         bytes calldata cbdata,
         bytes calldata ctx
     ) external override returns (bytes memory) {

--- a/contracts/strategies/examples/sqf-superfluid/RecipientSuperApp.sol
+++ b/contracts/strategies/examples/sqf-superfluid/RecipientSuperApp.sol
@@ -187,13 +187,12 @@ contract RecipientSuperApp is ISuperApp {
     /// ================================
 
     /// @dev This callback is called before the flow is created
-    function beforeAgreementCreated(
-        ISuperToken,
-        address,
-        bytes32,
-        bytes calldata,
-        bytes calldata
-    ) external pure override returns (bytes memory beforeData) {
+    function beforeAgreementCreated(ISuperToken, address, bytes32, bytes calldata, bytes calldata)
+        external
+        pure
+        override
+        returns (bytes memory beforeData)
+    {
         return "0x";
     }
 
@@ -236,7 +235,7 @@ contract RecipientSuperApp is ISuperApp {
     function beforeAgreementUpdated(
         ISuperToken superToken,
         address agreementClass,
-        bytes32 ,
+        bytes32,
         bytes calldata agreementData,
         bytes calldata
     ) external view override returns (bytes memory) {

--- a/contracts/strategies/examples/sqf-superfluid/SQFSuperfluid.sol
+++ b/contracts/strategies/examples/sqf-superfluid/SQFSuperfluid.sol
@@ -311,9 +311,7 @@ contract SQFSuperfluid is
 
     /// @dev prevent the pool token from being withdrawn
     /// @param _token The token address
-    /// @param _amount The amount to withdraw
-    /// @param _recipient The address to withdraw to
-    function _beforeWithdraw(address _token, uint256 _amount, address _recipient) internal override {
+    function _beforeWithdraw(address _token, uint256, address) internal override {
         if (_token == address(poolSuperToken)) {
             revert INVALID();
         }
@@ -340,10 +338,9 @@ contract SQFSuperfluid is
 
     /// @dev If the recipient is accepted, create a super app for the recipient
     /// @param _newStatus The new status
-    /// @param _oldStatus The old status
     /// @param _recipientIndex The index of the recipient
     /// @return _reviewedStatus The reviewed status
-    function _reviewRecipientStatus(Status _newStatus, Status _oldStatus, uint256 _recipientIndex)
+    function _reviewRecipientStatus(Status _newStatus, Status, uint256 _recipientIndex)
         internal
         override
         nonReentrant
@@ -371,10 +368,9 @@ contract SQFSuperfluid is
     /// @notice This will distribute funds (tokens) to recipients.
     /// @dev most strategies will track a TOTAL amount per recipient, and a PAID amount, and pay the difference
     /// this contract will need to track the amount paid already, so that it doesn't double pay.
-    /// @param _recipientsAddresses NOT USED
     /// @param _data Data required will depend on the strategy implementation
     /// @param _sender The address of the sender
-    function _distribute(address[] memory _recipientsAddresses, bytes memory _data, address _sender)
+    function _distribute(address[] memory, bytes memory _data, address _sender)
         internal
         override
         onlyPoolManager(_sender)
@@ -390,12 +386,11 @@ contract SQFSuperfluid is
     /// @notice This will allocate to recipients.
     /// @dev The encoded '_data' will be determined by the strategy implementation.
     /// @param _recipientsAddresses The addresses of the recipients to allocate to
-    /// @param _amounts The amounts to allocate to each recipient
     /// @param _data The data to use to allocate to the recipient
     /// @param _sender The address of the sender
     function _allocate(
         address[] memory _recipientsAddresses,
-        uint256[] memory _amounts,
+        uint256[] memory,
         bytes memory _data,
         address _sender
     ) internal override onlyActiveAllocation {

--- a/contracts/strategies/examples/sqf-superfluid/SQFSuperfluid.sol
+++ b/contracts/strategies/examples/sqf-superfluid/SQFSuperfluid.sol
@@ -388,12 +388,11 @@ contract SQFSuperfluid is
     /// @param _recipientsAddresses The addresses of the recipients to allocate to
     /// @param _data The data to use to allocate to the recipient
     /// @param _sender The address of the sender
-    function _allocate(
-        address[] memory _recipientsAddresses,
-        uint256[] memory,
-        bytes memory _data,
-        address _sender
-    ) internal override onlyActiveAllocation {
+    function _allocate(address[] memory _recipientsAddresses, uint256[] memory, bytes memory _data, address _sender)
+        internal
+        override
+        onlyActiveAllocation
+    {
         if (!_isValidAllocator(_sender)) revert UNAUTHORIZED();
 
         int96[] memory flowRates = abi.decode(_data, (int96[]));

--- a/contracts/strategies/extensions/register/RecipientsExtension.sol
+++ b/contracts/strategies/extensions/register/RecipientsExtension.sol
@@ -384,10 +384,8 @@ abstract contract RecipientsExtension is BaseStrategy, IRecipientsExtension, Err
     /// @notice Hook to review each new recipient status when REVIEW_EACH_STATUS is set to true
     /// @dev Beware of gas costs, since this function will be called for each reviewed recipient
     /// @param _newStatus New proposed status
-    /// @param _oldStatus Previous status
-    /// @param _recipientIndex The index of the recipient in case the recipient data needs to be accessed
     /// @return _reviewedStatus The actual new status to use
-    function _reviewRecipientStatus(Status _newStatus, Status _oldStatus, uint256 _recipientIndex)
+    function _reviewRecipientStatus(Status _newStatus, Status, uint256)
         internal
         virtual
         returns (Status _reviewedStatus)

--- a/foundry.toml
+++ b/foundry.toml
@@ -9,12 +9,9 @@ libs = ['node_modules', 'lib']
 test = 'test'
 cache_path = 'cache_forge'
 ignored_warnings_from = [
-  'test/invariant/fuzz/helpers/Pools.t.sol',
-  'test/invariant/fuzz/handlers/HandlerRegistry.t.sol',
-  'test/invariant/fuzz/helpers/FuzzBaseStrategy.t.sol',
-  'test/invariant/fuzz/properties/PropertiesAllo.t.sol',
-  'test/invariant/fuzz/properties/PropertiesStrategies.t.sol',
-  'test/invariant/fuzz/handlers/HandlerStrategy.t.sol',
+  'test/invariant/fuzz/',
+  'test/smock/',
+  'test/mocks/',
 ]
 
 # Gas reporting

--- a/foundry.toml
+++ b/foundry.toml
@@ -8,6 +8,14 @@ out = 'out'
 libs = ['node_modules', 'lib']
 test = 'test'
 cache_path = 'cache_forge'
+ignored_warnings_from = [
+  'test/invariant/fuzz/helpers/Pools.t.sol',
+  'test/invariant/fuzz/handlers/HandlerRegistry.t.sol',
+  'test/invariant/fuzz/helpers/FuzzBaseStrategy.t.sol',
+  'test/invariant/fuzz/properties/PropertiesAllo.t.sol',
+  'test/invariant/fuzz/properties/PropertiesStrategies.t.sol',
+  'test/invariant/fuzz/handlers/HandlerStrategy.t.sol',
+]
 
 # Gas reporting
 gas_reports = [

--- a/test/integration/DonationVotingMerkleDistribution.t.sol
+++ b/test/integration/DonationVotingMerkleDistribution.t.sol
@@ -129,7 +129,8 @@ contract IntegrationDonationVotingMerkleDistributionBase is IntegrationBase {
 
         // NOTE: removing all the ETH from the strategy before testing
         vm.prank(address(strategy));
-        address(0).call{value: address(strategy).balance}("");
+        (bool success, ) = address(0).call{value: address(strategy).balance}("");
+        require(success, "Failed to send ETH");
     }
 }
 

--- a/test/integration/DonationVotingMerkleDistribution.t.sol
+++ b/test/integration/DonationVotingMerkleDistribution.t.sol
@@ -129,7 +129,7 @@ contract IntegrationDonationVotingMerkleDistributionBase is IntegrationBase {
 
         // NOTE: removing all the ETH from the strategy before testing
         vm.prank(address(strategy));
-        (bool success, ) = address(0).call{value: address(strategy).balance}("");
+        (bool success,) = address(0).call{value: address(strategy).balance}("");
         require(success, "Failed to send ETH");
     }
 }

--- a/test/integration/DonationVotingOffchain.t.sol
+++ b/test/integration/DonationVotingOffchain.t.sol
@@ -127,7 +127,7 @@ contract IntegrationDonationVotingOffchainBase is IntegrationBase {
 
         // NOTE: removing all the ETH from the strategy before testing
         vm.prank(address(strategy));
-        (bool success, ) = address(0).call{value: address(strategy).balance}("");
+        (bool success,) = address(0).call{value: address(strategy).balance}("");
         require(success, "Failed to send ETH");
     }
 }

--- a/test/integration/DonationVotingOffchain.t.sol
+++ b/test/integration/DonationVotingOffchain.t.sol
@@ -127,7 +127,8 @@ contract IntegrationDonationVotingOffchainBase is IntegrationBase {
 
         // NOTE: removing all the ETH from the strategy before testing
         vm.prank(address(strategy));
-        address(0).call{value: address(strategy).balance}("");
+        (bool success, ) = address(0).call{value: address(strategy).balance}("");
+        require(success, "Failed to send ETH");
     }
 }
 

--- a/test/integration/DonationVotingOnchain.t.sol
+++ b/test/integration/DonationVotingOnchain.t.sol
@@ -99,7 +99,8 @@ contract IntegrationDonationVotingOnchainBase is IntegrationBase {
 
         // NOTE: removing all the ETH from the strategy before testing
         vm.prank(address(strategy));
-        address(0).call{value: address(strategy).balance}("");
+        (bool success, ) = address(0).call{value: address(strategy).balance}("");
+        require(success, "Failed to send ETH");
     }
 }
 

--- a/test/integration/DonationVotingOnchain.t.sol
+++ b/test/integration/DonationVotingOnchain.t.sol
@@ -99,7 +99,7 @@ contract IntegrationDonationVotingOnchainBase is IntegrationBase {
 
         // NOTE: removing all the ETH from the strategy before testing
         vm.prank(address(strategy));
-        (bool success, ) = address(0).call{value: address(strategy).balance}("");
+        (bool success,) = address(0).call{value: address(strategy).balance}("");
         require(success, "Failed to send ETH");
     }
 }

--- a/test/mocks/MockGatingExtension.sol
+++ b/test/mocks/MockGatingExtension.sol
@@ -9,7 +9,7 @@ import {TokenGatingExtension} from "strategies/extensions/gating/TokenGatingExte
 contract MockGatingExtension is EASGatingExtension, NFTGatingExtension, TokenGatingExtension {
     constructor(address _allo, string memory _strategyName) BaseStrategy(_allo, _strategyName) {}
 
-    function _initializeStrategy(uint256 _poolId, bytes memory _data) internal override {
+    function _initializeStrategy(uint256, bytes memory _data) internal override {
         address _eas = abi.decode(_data, (address));
 
         __EASGatingExtension_init(_eas);

--- a/test/mocks/smock-mocks/MockAllocationExtension.sol
+++ b/test/mocks/smock-mocks/MockAllocationExtension.sol
@@ -8,14 +8,14 @@ import {BaseStrategy} from "contracts/strategies/BaseStrategy.sol";
 contract MockAllocationExtension is BaseStrategy, AllocationExtension {
     constructor(address _allo, string memory _strategyName) BaseStrategy(_allo, _strategyName) {}
 
-    function initialize(uint256 _poolId, bytes memory _data) external override {
+    function initialize(uint256 _poolId, bytes memory __data) external override {
         __BaseStrategy_init(_poolId);
         (
             address[] memory _allowedTokens,
             uint64 _allocationStartTime,
             uint64 _allocationEndTime,
             bool _isUsingAllocationMetadata
-        ) = abi.decode(_data, (address[], uint64, uint64, bool));
+        ) = abi.decode(__data, (address[], uint64, uint64, bool));
         __AllocationExtension_init(_allowedTokens, _allocationStartTime, _allocationEndTime, _isUsingAllocationMetadata);
     }
 

--- a/test/mocks/smock-mocks/MockAllocatorsAllowlistExtension.sol
+++ b/test/mocks/smock-mocks/MockAllocatorsAllowlistExtension.sol
@@ -7,14 +7,14 @@ import {BaseStrategy} from "contracts/strategies/BaseStrategy.sol";
 contract MockAllocatorsAllowlistExtension is BaseStrategy, AllocatorsAllowlistExtension {
     constructor(address _allo, string memory _strategyName) BaseStrategy(_allo, _strategyName) {}
 
-    function initialize(uint256 _poolId, bytes memory _data) external override {
+    function initialize(uint256 _poolId, bytes memory __data) external override {
         __BaseStrategy_init(_poolId);
         (
             address[] memory _allowedTokens,
             uint64 _allocationStartTime,
             uint64 _allocationEndTime,
             bool _isUsingAllocationMetadata
-        ) = abi.decode(_data, (address[], uint64, uint64, bool));
+        ) = abi.decode(__data, (address[], uint64, uint64, bool));
         __AllocationExtension_init(_allowedTokens, _allocationStartTime, _allocationEndTime, _isUsingAllocationMetadata);
     }
 

--- a/test/mocks/smock-mocks/MockBaseStrategy.sol
+++ b/test/mocks/smock-mocks/MockBaseStrategy.sol
@@ -18,20 +18,20 @@ contract MockBaseStrategy is BaseStrategy {
         super._checkOnlyPoolManager(_sender);
     }
 
-    function _register(address[] memory _recipients, bytes memory _data, address _sender)
+    function _register(address[] memory _recipients, bytes memory __data, address _sender)
         internal
         virtual
         override
         returns (address[] memory _recipientIds)
     {}
 
-    function _allocate(address[] memory _recipients, uint256[] memory _amounts, bytes memory _data, address _sender)
+    function _allocate(address[] memory _recipients, uint256[] memory _amounts, bytes memory __data, address _sender)
         internal
         virtual
         override
     {}
 
-    function _distribute(address[] memory _recipientIds, bytes memory _data, address _sender)
+    function _distribute(address[] memory _recipientIds, bytes memory __data, address _sender)
         internal
         virtual
         override
@@ -45,37 +45,37 @@ contract MockBaseStrategy is BaseStrategy {
 
     function _afterWithdraw(address _token, uint256 _amount, address _recipient) internal virtual override {}
 
-    function _beforeRegisterRecipient(address[] memory _recipients, bytes memory _data, address _sender)
+    function _beforeRegisterRecipient(address[] memory _recipients, bytes memory __data, address _sender)
         internal
         virtual
         override
     {}
 
-    function _afterRegisterRecipient(address[] memory _recipients, bytes memory _data, address _sender)
+    function _afterRegisterRecipient(address[] memory _recipients, bytes memory __data, address _sender)
         internal
         virtual
         override
     {}
 
-    function _beforeAllocate(address[] memory _recipients, bytes memory _data, address _sender)
+    function _beforeAllocate(address[] memory _recipients, bytes memory __data, address _sender)
         internal
         virtual
         override
     {}
 
-    function _afterAllocate(address[] memory _recipients, bytes memory _data, address _sender)
+    function _afterAllocate(address[] memory _recipients, bytes memory __data, address _sender)
         internal
         virtual
         override
     {}
 
-    function _beforeDistribute(address[] memory _recipientIds, bytes memory _data, address _sender)
+    function _beforeDistribute(address[] memory _recipientIds, bytes memory __data, address _sender)
         internal
         virtual
         override
     {}
 
-    function _afterDistribute(address[] memory _recipientIds, bytes memory _data, address _sender)
+    function _afterDistribute(address[] memory _recipientIds, bytes memory __data, address _sender)
         internal
         virtual
         override

--- a/test/mocks/smock-mocks/MockEASGatingExtension.sol
+++ b/test/mocks/smock-mocks/MockEASGatingExtension.sol
@@ -7,9 +7,9 @@ import {BaseStrategy} from "contracts/strategies/BaseStrategy.sol";
 contract MockEASGatingExtension is BaseStrategy, EASGatingExtension {
     constructor(address _allo, string memory _strategyName) BaseStrategy(_allo, _strategyName) {}
 
-    function initialize(uint256 _poolId, bytes memory _data) external virtual override {
+    function initialize(uint256 _poolId, bytes memory __data) external virtual override {
         __BaseStrategy_init(_poolId);
-        __EASGatingExtension_init(abi.decode(_data, (address)));
+        __EASGatingExtension_init(abi.decode(__data, (address)));
     }
 
     function __EASGatingExtension_init(address _eas) internal virtual override {

--- a/test/mocks/smock-mocks/MockMilestonesExtension.sol
+++ b/test/mocks/smock-mocks/MockMilestonesExtension.sol
@@ -12,26 +12,26 @@ contract MockMilestonesExtension is BaseStrategy, IMilestonesExtension, Mileston
 
     constructor(address _allo, string memory _strategyName) BaseStrategy(_allo, _strategyName) {}
 
-    function initialize(uint256 _poolId, bytes memory _data) external override {
+    function initialize(uint256 _poolId, bytes memory __data) external override {
         __BaseStrategy_init(_poolId);
 
-        uint256 _maxBid = abi.decode(_data, (uint256));
+        uint256 _maxBid = abi.decode(__data, (uint256));
         __MilestonesExtension_init(_maxBid);
     }
 
-    function _allocate(address[] memory _recipients, uint256[] memory _amounts, bytes memory _data, address _sender)
+    function _allocate(address[] memory _recipients, uint256[] memory _amounts, bytes memory __data, address _sender)
         internal
         virtual
         override
     {}
 
-    function _distribute(address[] memory _recipientIds, bytes memory _data, address _sender)
+    function _distribute(address[] memory _recipientIds, bytes memory __data, address _sender)
         internal
         virtual
         override
     {}
 
-    function _register(address[] memory __recipients, bytes memory _data, address _sender)
+    function _register(address[] memory __recipients, bytes memory __data, address _sender)
         internal
         virtual
         override

--- a/test/mocks/smock-mocks/MockRecipientsExtension.sol
+++ b/test/mocks/smock-mocks/MockRecipientsExtension.sol
@@ -12,19 +12,19 @@ contract MockRecipientsExtension is BaseStrategy, RecipientsExtension {
         BaseStrategy(_allo, _strategyName)
     {}
 
-    function initialize(uint256 _poolId, bytes memory _data) external override {
+    function initialize(uint256 _poolId, bytes memory __data) external override {
         __BaseStrategy_init(_poolId);
 
-        RecipientInitializeData memory _initializeData = abi.decode(_data, (RecipientInitializeData));
+        RecipientInitializeData memory _initializeData = abi.decode(__data, (RecipientInitializeData));
         __RecipientsExtension_init(_initializeData);
     }
 
-    function _allocate(address[] memory _recipients, uint256[] memory _amounts, bytes memory _data, address _sender)
+    function _allocate(address[] memory _recipients, uint256[] memory _amounts, bytes memory __data, address _sender)
         internal
         override
     {}
 
-    function _distribute(address[] memory _recipientIds, bytes memory _data, address _sender) internal override {}
+    function _distribute(address[] memory _recipientIds, bytes memory __data, address _sender) internal override {}
 
     function __RecipientsExtension_init(IRecipientsExtension.RecipientInitializeData memory _initializeData)
         internal

--- a/test/unit/core/AnchorUnit.t.sol
+++ b/test/unit/core/AnchorUnit.t.sol
@@ -124,13 +124,14 @@ contract AnchorUnit is Test {
 
     function test_ReceiveShouldReceiveNativeTokens(uint256 _value) external {
         // it should receive native tokens
-        (Anchor _anchor, address _registry, bytes32 _profileId) = _initAnchor();
+        (Anchor _anchor, , ) = _initAnchor();
 
         assertEq(address(_anchor).balance, 0); // Check if the balance of the contract has been updated
 
         hoax(makeAddr("funder"), _value);
 
-        address(_anchor).call{value: _value}("");
+        (bool success, ) = address(_anchor).call{value: _value}("");
+        require(success, "Failed to send ETH");
 
         assertEq(address(_anchor).balance, _value); // Check if the balance of the contract has been updated
     }
@@ -142,7 +143,7 @@ contract AnchorUnit is Test {
         bytes memory _data
     ) external {
         // it should return the onERC721Received selector
-        (Anchor _anchor, address _registry, bytes32 _profileId) = _initAnchor();
+        (Anchor _anchor, , ) = _initAnchor();
 
         bytes4 retval = _anchor.onERC721Received(_operator, _from, _tokenId, _data);
         assertEq(retval, IERC721Receiver.onERC721Received.selector);
@@ -156,7 +157,7 @@ contract AnchorUnit is Test {
         bytes memory _data
     ) external {
         // it should return the onERC1155Received selector
-        (Anchor _anchor, address _registry, bytes32 _profileId) = _initAnchor();
+        (Anchor _anchor, , ) = _initAnchor();
 
         bytes4 retval = _anchor.onERC1155Received(_operator, _from, _tokenId, _value, _data);
         assertEq(retval, IERC1155Receiver.onERC1155Received.selector);
@@ -170,7 +171,7 @@ contract AnchorUnit is Test {
         bytes memory _data
     ) external {
         // it should return the onERC1155BatchReceived selector
-        (Anchor _anchor, address _registry, bytes32 _profileId) = _initAnchor();
+        (Anchor _anchor, , ) = _initAnchor();
 
         bytes4 retval = _anchor.onERC1155BatchReceived(_operator, _from, _tokenIds, _values, _data);
         assertEq(retval, IERC1155Receiver.onERC1155BatchReceived.selector);

--- a/test/unit/core/AnchorUnit.t.sol
+++ b/test/unit/core/AnchorUnit.t.sol
@@ -124,13 +124,13 @@ contract AnchorUnit is Test {
 
     function test_ReceiveShouldReceiveNativeTokens(uint256 _value) external {
         // it should receive native tokens
-        (Anchor _anchor, , ) = _initAnchor();
+        (Anchor _anchor,,) = _initAnchor();
 
         assertEq(address(_anchor).balance, 0); // Check if the balance of the contract has been updated
 
         hoax(makeAddr("funder"), _value);
 
-        (bool success, ) = address(_anchor).call{value: _value}("");
+        (bool success,) = address(_anchor).call{value: _value}("");
         require(success, "Failed to send ETH");
 
         assertEq(address(_anchor).balance, _value); // Check if the balance of the contract has been updated
@@ -143,7 +143,7 @@ contract AnchorUnit is Test {
         bytes memory _data
     ) external {
         // it should return the onERC721Received selector
-        (Anchor _anchor, , ) = _initAnchor();
+        (Anchor _anchor,,) = _initAnchor();
 
         bytes4 retval = _anchor.onERC721Received(_operator, _from, _tokenId, _data);
         assertEq(retval, IERC721Receiver.onERC721Received.selector);
@@ -157,7 +157,7 @@ contract AnchorUnit is Test {
         bytes memory _data
     ) external {
         // it should return the onERC1155Received selector
-        (Anchor _anchor, , ) = _initAnchor();
+        (Anchor _anchor,,) = _initAnchor();
 
         bytes4 retval = _anchor.onERC1155Received(_operator, _from, _tokenId, _value, _data);
         assertEq(retval, IERC1155Receiver.onERC1155Received.selector);
@@ -171,7 +171,7 @@ contract AnchorUnit is Test {
         bytes memory _data
     ) external {
         // it should return the onERC1155BatchReceived selector
-        (Anchor _anchor, , ) = _initAnchor();
+        (Anchor _anchor,,) = _initAnchor();
 
         bytes4 retval = _anchor.onERC1155BatchReceived(_operator, _from, _tokenIds, _values, _data);
         assertEq(retval, IERC1155Receiver.onERC1155BatchReceived.selector);

--- a/test/unit/strategies/extensions/RecipientsExtensionUnit.t.sol
+++ b/test/unit/strategies/extensions/RecipientsExtensionUnit.t.sol
@@ -689,7 +689,6 @@ contract RecipientsExtensionUnit is Test {
     }
 
     function test__extractRecipientAndMetadataRevertWhen_IsNotAProfileMember(
-        address _recipientIdOrRegistryAnchor,
         address _sender,
         Metadata memory _metadata,
         _extractRecipientAndMetadataParam memory _param
@@ -865,7 +864,6 @@ contract RecipientsExtensionUnit is Test {
         for (uint256 col = 0; col < 64; col++) {
             uint256 colIndex = col << 2; // col * 4
             uint8 newStatus = uint8((reviewedFullRow >> colIndex) & 0xF);
-            uint8 proposedStatus = uint8((_fullRow >> colIndex) & 0xF);
             assertEq(newStatus, _reviewedStatus);
         }
     }


### PR DESCRIPTION
- Ignored some paths, preventing compiler warnings from those files. (Smock, mocks, invariants).
- Removed unused parameters, when running `yarn lint:natspec` several warnings will appear because of this, but I think it's worth the trade-off.
- We reduced the warnings to only 6 warnings that are harder to fix.