### PR TITLE
fix: change constant, update tests

### DIFF
--- a/contracts/strategies/extensions/allocate/AllocationExtension.sol
+++ b/contracts/strategies/extensions/allocate/AllocationExtension.sol
@@ -11,7 +11,7 @@ abstract contract AllocationExtension is BaseStrategy, IAllocationExtension {
     /// ================================
 
     /// @notice The address sent when all tokens are allowed
-    address public constant ALL_TOKENS_ALLOWED = address(0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE);
+    address public constant ALL_TOKENS_ALLOWED = address(0xeeeEEeEEEEEeeEEEeEeE00000000000000000000);
 
     /// @notice The start time for allocations
     uint64 public allocationStartTime;
@@ -46,6 +46,7 @@ abstract contract AllocationExtension is BaseStrategy, IAllocationExtension {
         } else {
             for (uint256 i; i < _allowedTokens.length; i++) {
                 if (_allowedTokens[i] == address(0)) revert AllocationExtension_ZERO_ADDRESS_NOT_ALLOWED();
+                if (_allowedTokens[i] == ALL_TOKENS_ALLOWED) revert AllocationExtension_ADDRESS_NOT_ALLOWED();
                 allowedTokens[_allowedTokens[i]] = true;
             }
         }

--- a/contracts/strategies/extensions/allocate/IAllocationExtension.sol
+++ b/contracts/strategies/extensions/allocate/IAllocationExtension.sol
@@ -20,6 +20,9 @@ interface IAllocationExtension {
     /// @dev Error thrown when sending the zero address as a token
     error AllocationExtension_ZERO_ADDRESS_NOT_ALLOWED();
 
+    /// @dev Error thrown when sending the ALL_TOKENS_ALLOWED address as a token
+    error AllocationExtension_ADDRESS_NOT_ALLOWED();
+
     /// @notice Emitted when the allocation timestamps are updated
     /// @param allocationStartTime The start time for the allocation period
     /// @param allocationEndTime The end time for the allocation period

--- a/test/unit/strategies/extensions/AllocationExtensionUnit.t.sol
+++ b/test/unit/strategies/extensions/AllocationExtensionUnit.t.sol
@@ -31,6 +31,7 @@ contract AllocationExtension is Test {
     function test___AllocationExtension_initWhenAllowedTokensArrayIsNotEmpty(address[] memory _tokens) external {
         for (uint256 i; i < _tokens.length; i++) {
             vm.assume(_tokens[i] != address(0));
+            vm.assume(_tokens[i] != extension.ALL_TOKENS_ALLOWED());
         }
 
         extension.call___AllocationExtension_init(_tokens, 0, 0, false);
@@ -39,6 +40,16 @@ contract AllocationExtension is Test {
         for (uint256 i; i < _tokens.length; i++) {
             assertTrue(extension.allowedTokens(_tokens[i]));
         }
+    }
+
+    function test___AllocationExtension_initRevertWhen_AllowedTokensArrayIncludesALL_TOKENS_ALLOWED() external {
+        address[] memory _tokens = new address[](1);
+        _tokens[0] = extension.ALL_TOKENS_ALLOWED();
+
+        // It should revert
+        vm.expectRevert(IAllocationExtension.AllocationExtension_ADDRESS_NOT_ALLOWED.selector);
+
+        extension.call___AllocationExtension_init(_tokens, 0, 0, false);
     }
 
     function test___AllocationExtension_initShouldSetIsUsingAllocationMetadata(bool _isUsingAllocationMetadata)
@@ -72,6 +83,7 @@ contract AllocationExtension is Test {
 
     function test__isAllowedTokenWhenTheTokenSentIsAllowed(address _tokenToCheck) external {
         vm.assume(_tokenToCheck != address(0));
+        vm.assume(_tokenToCheck != extension.ALL_TOKENS_ALLOWED());
 
         // Send array with only that token
         address[] memory tokens = new address[](1);

--- a/test/unit/strategies/extensions/AllocationExtensionUnit.tree
+++ b/test/unit/strategies/extensions/AllocationExtensionUnit.tree
@@ -5,6 +5,8 @@ AllocationExtension::__AllocationExtension_init
 │   └── It should mark address of all tokens allowed as true
 ├── When allowedTokens array is not empty
 │   └── It should mark the tokens in the array as true
+├── When allowedTokens array includes ALL_TOKENS_ALLOWED
+│   └── It should revert
 ├── It should set isUsingAllocationMetadata
 └── It should call _updateAllocationTimestamps
 


### PR DESCRIPTION
The constant `ALL_TOKENS_ALLOWED` was the same that is often used to represent the native token. Changed the constant and updated the tests.